### PR TITLE
Enable using TBCStopwatch without the RAII feature

### DIFF
--- a/TBCCore/TBCStopwatch.h
+++ b/TBCCore/TBCStopwatch.h
@@ -8,6 +8,7 @@ typedef void (^TBCStopwatchBlock)(NSTimeInterval interval);
 
 @property (nonatomic,assign) BOOL firesOnDealloc;
 
+- (instancetype)init;
 - (instancetype)initWithBlock:(TBCStopwatchBlock)block;
 - (instancetype)initWithQueue:(dispatch_queue_t)queue block:(TBCStopwatchBlock)block __attribute__((objc_designated_initializer));
 
@@ -17,5 +18,8 @@ typedef void (^TBCStopwatchBlock)(NSTimeInterval interval);
 - (void)stop;
 
 - (void)cancel;
+
+- (NSTimeInterval)currentTimeInterval;
+- (BOOL)isActive;
 
 @end

--- a/TBCCore/TBCStopwatch.m
+++ b/TBCCore/TBCStopwatch.m
@@ -18,13 +18,15 @@ typedef NS_ENUM(NSUInteger, TBCStopwatchState) {
     NSDate *_chunkStartDate;
 }
 
+- (instancetype)init {
+    return [self initWithQueue:nil block:nil];
+}
+
 - (instancetype)initWithBlock:(TBCStopwatchBlock)block {
     return [self initWithQueue:nil block:block];
 }
 
 - (instancetype)initWithQueue:(dispatch_queue_t)queue block:(TBCStopwatchBlock)block {
-    NSParameterAssert(block);
-
     if (!queue) {
         queue = dispatch_get_main_queue();
     }
@@ -91,6 +93,24 @@ typedef NS_ENUM(NSUInteger, TBCStopwatchState) {
 
 - (void)cancel {
     _state = TBCStopwatchNotStarted;
+}
+
+- (NSTimeInterval)currentTimeInterval {
+    NSTimeInterval result = _durationOfPreviousChunks;
+    if (_state == TBCStopwatchRunning) {
+        result += [[NSDate date] timeIntervalSinceDate:_chunkStartDate];
+    }
+    return result;
+}
+
+- (BOOL)isActive {
+    switch (_state) {
+        case TBCStopwatchNotStarted:
+            return NO;
+        case TBCStopwatchRunning:
+        case TBCStopwatchPaused:
+            return YES;
+    }
 }
 
 - (void)tbc_beginChunk {


### PR DESCRIPTION
@TabDigital/mobile
- Allow not specifying a block at init
- Expose the current elapsed time interval
- Expose whether the stopwatch is active
